### PR TITLE
Debugging with Akshat and new model switch

### DIFF
--- a/src/frontend/aigentqube-dashboard/src/services/api/MetisIntegration.ts
+++ b/src/frontend/aigentqube-dashboard/src/services/api/MetisIntegration.ts
@@ -126,9 +126,15 @@ export class MetisIntegration implements APIIntegration {
           // ...(iqube.walletsOfInterest || [])
         ])
         .filter(key => typeof key === "string" && key.startsWith("0x"));
+        const uniqueKeys = Array.from(new Set(keys));
+        const uniqueIqubesArray = iqubesArray.filter(iqube => 
+          uniqueKeys.some(key => 
+            key === iqube.evmPublicKey
+          )
+        );
 
       const metis_data = {
-        "public_keys": keys,
+        "public_keys": uniqueKeys,
         "user_profile": {
           "Name": " ",
           "Number": " ",

--- a/src/frontend/aigentqube-dashboard/src/services/api/VeniceIntegration.ts
+++ b/src/frontend/aigentqube-dashboard/src/services/api/VeniceIntegration.ts
@@ -25,7 +25,7 @@ export class VeniceIntegration implements APIIntegration {
     private readonly MAX_RETRIES = 3;
     private readonly RETRY_DELAY = 1000; // 1 second
     private readonly MAX_HISTORY_LENGTH = 10;
-    private readonly DEFAULT_MODEL = 'deepseek-r1-671b'
+    private readonly DEFAULT_MODEL = 'llama-3.3-70b'
 
     private readonly SYSTEM_PROMPTS: Record<string, string> = {
         'default': `You are an advanced AI assistant integrated with the AigentQube platform. 


### PR DESCRIPTION
Akshat believes EVM duplicate addressing causes bugs -- added fix to prevent duplicate addresses being sent

Venice AI now uses Llama instead of Deepseek as default model. Tech debt in commit message.